### PR TITLE
fix(dicom): image reading error when singleSortedSeries is true

### DIFF
--- a/packages/dicom/typescript/src/read-image-dicom-file-series.ts
+++ b/packages/dicom/typescript/src/read-image-dicom-file-series.ts
@@ -27,19 +27,17 @@ async function readImageDicomFileSeries(
     workerPool = new WorkerPool(numberOfWorkers, readImageDicomFileSeriesWorkerFunction)
   }
 
-  const inputs: Array<BinaryFile> = [
-  ]
   if(options.inputImages.length < 1) {
     throw new Error('"input-images" option must have a length > 1')
   }
 
-  await Promise.all(options.inputImages.map(async (value) => {
+  const inputs: Array<BinaryFile> = await Promise.all(options.inputImages.map(async (value) => {
     let valueFile = value
     if (value instanceof File) {
       const valueBuffer = await value.arrayBuffer()
       valueFile = { path: value.name, data: new Uint8Array(valueBuffer) }
     }
-    inputs.push(valueFile as BinaryFile)
+    return valueFile as BinaryFile
   }))
 
   if (options.singleSortedSeries) {


### PR DESCRIPTION
Ensure inputs and options.inputImages order consistency to prevent image reading errors when singleSortedSeries flag is enabled.